### PR TITLE
Implement Avg min max

### DIFF
--- a/python/tvm/hago/analysis.py
+++ b/python/tvm/hago/analysis.py
@@ -37,7 +37,7 @@ class Stats(object):
         data: intermediate data * number_of_batches
         """
         self.data = data
-        # FIXME - Add quantize ranges.
+        # FIXME - Add quantile ranges.
         # Range represents avg min/max
         self.range = []
         self.power_of_two_range = []

--- a/python/tvm/hago/base.py
+++ b/python/tvm/hago/base.py
@@ -45,7 +45,7 @@ class QConfig(Object):
 
     _node_defaults = {
         "skip_conv_layers": [0],
-        "threshold_estimate_method": "avg_min_max_range",
+        "threshold_estimate_method": "avg_range",
         "global_scale": 8.0,
         "log_file": ".quantize_strategy_search.log",
         # "do_simulation": False,

--- a/python/tvm/hago/record.py
+++ b/python/tvm/hago/record.py
@@ -76,7 +76,7 @@ def serialize(obj):
             if hasattr(obj, '__dict__'):
                 return obj.__dict__
             return json.JSONEncoder.default(self, obj)
-    return json.dumps(obj, cls=Encoder)
+    return json.dumps(str(obj), cls=Encoder)
 
 
 def deserialize(json_str):

--- a/python/tvm/hago/search.py
+++ b/python/tvm/hago/search.py
@@ -400,9 +400,8 @@ class Tuner(object):
             trials = self.next_trials()
             measures = self._measure(trials)
 
-            # TODO - Failure in writing to file for avg_min_max
-            # if fout is not None:
-            #     self._write_to_file(fout, measures)
+            if fout is not None:
+                self._write_to_file(fout, measures)
             self.update(measures)
             num_trials += len(measures)
         return self.best_measure

--- a/python/tvm/hago/threshold.py
+++ b/python/tvm/hago/threshold.py
@@ -68,7 +68,7 @@ def threshold_estimate(graph, topology, stats, bits=None, rectify=True):
 
     if cfg.threshold_estimate_method == 'global_scale':
         thresholds = [cfg.global_scale for _ in exprs]
-    elif cfg.threshold_estimate_method == 'avg_min_max_range':
+    elif cfg.threshold_estimate_method == 'avg_range':
         thresholds = stats.range
     elif cfg.threshold_estimate_method == 'power_of_two_range':
         thresholds = stats.power_of_two_range

--- a/tests/python/nightly/quantization/learning_based_quantize.py
+++ b/tests/python/nightly/quantization/learning_based_quantize.py
@@ -92,7 +92,7 @@ def get_model(model_name, batch_size, qconfig, original=False, simulated=False, 
         logging.debug('quantize graph')
         logging.debug(quantized_graph.astext(show_meta_data=False))
         # hago.inspect_graph_statistic(graph, hardware, strategy, dataset, ctx, target)
-        return simulated_graph
+        return quantized_graph
 
 
 def eval_acc(mod, dataset, batch_fn, target='cuda', ctx=tvm.gpu(), log_interval=100):
@@ -142,7 +142,7 @@ def test_quantize_acc(cfg, rec_val):
     qconfig = hago.qconfig(skip_conv_layers=[0],
                            log_file='temp.log')
 
-    batch_size = 1
+    batch_size = 32
     val_data, batch_fn = get_val_data(cfg.model, rec_val=rec_val, batch_size=batch_size)
     dataset = get_calibration_dataset(val_data, batch_fn)
 


### PR DESCRIPTION
Primarily 2 features
* Average min max of intermediate tensors for calibration. As we target symmetric, we choose the absolute max of the avg min/max for the range.
* Use QNN requantize to support non-power-of-2 ranges.

Leads to accuracy improvements for MXNet Rn18 and Rn50.

Rn18
FP32 - validation: acc-top1=0.709460 acc-top5=0.899200
Quantized - validation: acc-top1=0.690660 acc-top5=0.888980
Accuracy drop = 1.8% Top1

Rn50
FP32 - validation: acc-top1=0.765020 acc-top5=0.931360
Quantized - validation: acc-top1=0.754400 acc-top5=0.924220
Accuracy drop = 1.06% Top1